### PR TITLE
Feat: Add esptool uart example

### DIFF
--- a/.build-test-rules.yml
+++ b/.build-test-rules.yml
@@ -7,6 +7,10 @@ examples/uart:
   enable:
     - if: IDF_TARGET in ["esp32s3", "esp32c6"]
 
+examples/uart_esptool:
+  enable:
+    - if: IDF_TARGET == "esp32"
+
 examples/usb_cdc:
   enable:
     - if: IDF_TARGET in ["esp32s3", "esp32p4"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 repos:
 - repo: https://github.com/igrr/astyle_py.git
-  rev: v0.9.1
+  rev: v1.1.0
   hooks:
     - id: astyle_py
       args: ['--style=otbs', '--attach-namespaces', '--attach-classes', '--indent=spaces=4', '--convert-tabs', '--align-pointer=name', '--align-reference=name', '--keep-one-line-statements', '--pad-header', '--pad-oper']
 
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.3.0
+  rev: v6.0.0
   hooks:
     - id: trailing-whitespace
       types_or: [c, c++]
@@ -19,7 +19,7 @@ repos:
       description: Forces to replace line ending by the UNIX 'lf' character
 
 - repo: https://github.com/espressif/doxybook
-  rev: v0.2.1
+  rev: v0.3.0
   hooks:
     - id: doxygen-api-md
       args: ["-i", "doxygen/xml", "-o", "./API.md"]

--- a/examples/uart_esptool/CMakeLists.txt
+++ b/examples/uart_esptool/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.16)
+
+set(COMPONENTS main)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+
+project(rfc2217-server-uart-esptool)
+

--- a/examples/uart_esptool/README.md
+++ b/examples/uart_esptool/README.md
@@ -1,0 +1,81 @@
+# RFC2217 UART Esptool Example
+
+This example sets up an RFC2217 server that emulates a serial port for esptool communication. It accepts client connections and forwards data between the RFC2217 client and UART, while also implementing the DTR/RTS control signals that esptool uses for programming ESP devices.
+
+The example is specifically designed to work with esptool for remote programming of ESP devices over the network. It implements the BOOT and EN GPIO control signals that esptool uses to put ESP devices into download mode, supports dynamic baudrate changes, and implements UART buffer purging for reliable programming.
+
+The example can be used with any ESP chip. You need to connect the target ESP device to the UART port of the ESP board running this example.
+
+Network connection is achieved using `protocols_examples_common` component, which provides a simple API for connecting to Wi-Fi or Ethernet. You can configure the connection method and the credentials in menuconfig.
+
+## Hardware Setup
+
+Connect the target ESP device to the UART port of the ESP board running this example:
+
+- Target ESP TX → ESP board RX (GPIO 5)
+- Target ESP RX → ESP board TX (GPIO 4)  
+- Target ESP GND → ESP board GND
+- Target ESP BOOT → ESP board BOOT (GPIO 26)
+- Target ESP EN → ESP board EN (GPIO 25)
+
+## How to Use the Example
+
+Build and flash the example as usual. For example, when using an ESP32 chip:
+
+```shell
+idf.py set-target esp32
+idf.py flash monitor
+```
+
+By default, the example uses UART1, GPIO 4 for TX and GPIO 5 for RX. It also configures GPIO 26 as BOOT and GPIO 25 as EN for esptool control signals. If you want to use different UART or GPIOs, you can change the configuration in menuconfig.
+
+Note the IP address printed on the console when the example runs. You will need it to connect to the device. For example:
+
+```text
+I (4547) example_common: Connected to example_netif_sta
+I (4557) example_common: - IPv4 address: 192.168.0.180,
+```
+
+After flashing, the device will start an RFC2217 server. You can now use esptool to program a target ESP device remotely over the network.
+
+## Programming with Esptool
+
+Now you can use esptool with the RFC2217 URL to program the target device remotely:
+
+```shell
+esptool.py --chip esp32 --port rfc2217://192.168.0.180:3333 write_flash 0x1000 your_firmware.bin
+```
+
+Replace `192.168.0.180` with the IP address of your ESP board and adjust the chip type and flash parameters as needed.
+
+## Testing with Miniterm
+
+You can also test the connection using `miniterm` from pySerial:
+
+```shell
+python -m serial.tools.miniterm rfc2217://192.168.0.180:3333 115200
+```
+
+Characters typed in miniterm will be forwarded to the target ESP device, and responses will be sent back.
+
+To exit miniterm, press `Ctrl+]`.
+
+## Example output
+
+```text
+I (4565) example_common: - IPv4 address: 192.168.0.180,
+I (4565) example_common: - IPv6 address: fe80:0000:0000:0000:1206:1cff:fe98:49dc, type: ESP_IP6_ADDR_IS_LINK_LOCAL
+I (4585) app_main: Starting RFC2217 server on port 3333
+I (4585) app_main: Waiting for client to connect
+I (9245) rfc2217_server: TCP receive thread started, socket: 55
+I (9255) app_main: Client connected, starting data transfer
+I (48895) rfc2217_server: Connection closed
+I (48895) rfc2217_server: TCP receive thread done
+I (48915) app_main: Client disconnected
+I (48915) app_main: Waiting for client to connect
+```
+
+The control signal mapping is:
+
+- DTR → BOOT GPIO (default: GPIO 26)
+- RTS → EN GPIO (default: GPIO 25)

--- a/examples/uart_esptool/main/CMakeLists.txt
+++ b/examples/uart_esptool/main/CMakeLists.txt
@@ -1,0 +1,4 @@
+idf_component_register(
+    SRCS "uart_esptool_main.c"
+    PRIV_INCLUDE_DIRS "."
+    PRIV_REQUIRES esp_system lwip nvs_flash esp_netif esp_event esp_driver_uart esp_driver_gpio)

--- a/examples/uart_esptool/main/Kconfig.projbuild
+++ b/examples/uart_esptool/main/Kconfig.projbuild
@@ -1,0 +1,32 @@
+menu "RFC2217 UART Example Configuration"
+
+    config EXAMPLE_UART_PORT_NUM
+        int "UART port number"
+        default 1
+        help
+            Select the UART port number to use for the RFC2217 UART example.
+
+    config EXAMPLE_UART_TX_GPIO
+        int "UART TX GPIO"
+        default 4
+        help
+            Select the GPIO number to use as the UART TX.
+
+    config EXAMPLE_UART_RX_GPIO
+        int "UART RX GPIO"
+        default 5
+        help
+            Select the GPIO number to use as the UART RX.
+
+    config EXAMPLE_BOOT_GPIO
+        int "BOOT GPIO"
+        default 26
+        help
+            Select the GPIO number to use as the BOOT GPIO.
+
+    config EXAMPLE_EN_GPIO
+        int "EN GPIO"
+        default 25
+        help
+            Select the GPIO number to use as the EN GPIO.
+endmenu

--- a/examples/uart_esptool/main/idf_component.yml
+++ b/examples/uart_esptool/main/idf_component.yml
@@ -1,0 +1,6 @@
+dependencies:
+  igrr/rfc2217-server:
+    version: "*"
+    override_path: ../../../
+  protocol_examples_common:
+    path: ${IDF_PATH}/examples/common_components/protocol_examples_common

--- a/examples/uart_esptool/main/uart_esptool_main.c
+++ b/examples/uart_esptool/main/uart_esptool_main.c
@@ -1,0 +1,180 @@
+#include <string.h>
+#include <stdlib.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "esp_err.h"
+#include "esp_check.h"
+#include "esp_event.h"
+#include "esp_log.h"
+#include "nvs_flash.h"
+#include "esp_netif.h"
+#include "esp_intr_alloc.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/semphr.h"
+#include "driver/uart.h"
+#include "driver/gpio.h"
+#include "protocol_examples_common.h"
+#include "sdkconfig.h"
+
+#include "rfc2217_server.h"
+
+static const char *TAG = "app_main";
+static rfc2217_server_t s_server;
+static SemaphoreHandle_t s_client_connected;
+static SemaphoreHandle_t s_client_disconnected;
+
+static void on_connected(void *ctx);
+static void on_disconnected(void *ctx);
+static void on_data_received(void *ctx, const uint8_t *data, size_t len);
+static unsigned on_baudrate(void *ctx, unsigned baudrate);
+static rfc2217_control_t on_control(void *ctx, rfc2217_control_t requested_control);
+static rfc2217_purge_t on_purge(void *ctx, rfc2217_purge_t requested_purge);
+
+static esp_err_t init_uart(void);
+static esp_err_t init_gpio(void);
+
+void app_main(void)
+{
+    ESP_ERROR_CHECK(nvs_flash_init());
+    ESP_ERROR_CHECK(esp_netif_init());
+    ESP_ERROR_CHECK(esp_event_loop_create_default());
+
+    ESP_ERROR_CHECK(example_connect());
+    ESP_ERROR_CHECK(init_uart());
+    ESP_ERROR_CHECK(init_gpio());
+
+    s_client_connected = xSemaphoreCreateBinary();
+    s_client_disconnected = xSemaphoreCreateBinary();
+
+    rfc2217_server_config_t config = {
+        .ctx = NULL,
+        .on_client_connected = on_connected,
+        .on_client_disconnected = on_disconnected,
+        .on_baudrate = on_baudrate,
+        .on_control = on_control,
+        .on_purge = on_purge,
+        .on_data_received = on_data_received,
+        .port = 3333,
+        .task_stack_size = 4096,
+        .task_priority = 5,
+        .task_core_id = 0
+    };
+
+    ESP_ERROR_CHECK(rfc2217_server_create(&config, &s_server));
+
+    ESP_LOGI(TAG, "Starting RFC2217 server on port %u", config.port);
+
+    ESP_ERROR_CHECK(rfc2217_server_start(s_server));
+
+    while (true) {
+        ESP_LOGI(TAG, "Waiting for client to connect");
+        xSemaphoreTake(s_client_connected, portMAX_DELAY);
+
+        ESP_LOGI(TAG, "Client connected, starting data transfer");
+
+        while (xSemaphoreTake(s_client_disconnected, 0) != pdTRUE) {
+            static uint8_t uart_read_buf[2048];
+            int len = uart_read_bytes(CONFIG_EXAMPLE_UART_PORT_NUM, uart_read_buf, sizeof(uart_read_buf), pdMS_TO_TICKS(10));
+            if (len > 0) {
+                rfc2217_server_send_data(s_server, uart_read_buf, len);
+            }
+        }
+
+        ESP_LOGI(TAG, "Client disconnected");
+    }
+}
+
+static void on_connected(void *ctx)
+{
+    xSemaphoreGive(s_client_connected);
+}
+
+static void on_disconnected(void *ctx)
+{
+    xSemaphoreGive(s_client_disconnected);
+}
+
+static rfc2217_purge_t on_purge(void *ctx, rfc2217_purge_t requested_purge)
+{
+    rfc2217_purge_t result = requested_purge; // Assume we can fulfill the request
+
+    switch (requested_purge) {
+    case RFC2217_PURGE_RECEIVE:
+        uart_flush_input(CONFIG_EXAMPLE_UART_PORT_NUM);
+        break;
+    case RFC2217_PURGE_TRANSMIT:
+        uart_wait_tx_done(CONFIG_EXAMPLE_UART_PORT_NUM, pdMS_TO_TICKS(1000));
+        break;
+    case RFC2217_PURGE_BOTH:
+        uart_flush_input(CONFIG_EXAMPLE_UART_PORT_NUM);
+        uart_wait_tx_done(CONFIG_EXAMPLE_UART_PORT_NUM, pdMS_TO_TICKS(1000));
+        break;
+    default:
+        result = 0;
+        break;
+    }
+
+    return result;
+}
+
+static void on_data_received(void *ctx, const uint8_t *data, size_t len)
+{
+    uart_write_bytes(CONFIG_EXAMPLE_UART_PORT_NUM, data, len);
+}
+
+static esp_err_t init_uart(void)
+{
+    uart_config_t uart_config = {
+        .baud_rate = 115200,
+        .data_bits = UART_DATA_8_BITS,
+        .parity = UART_PARITY_DISABLE,
+        .stop_bits = UART_STOP_BITS_1,
+        .flow_ctrl = UART_HW_FLOWCTRL_DISABLE
+    };
+    const size_t tx_buffer_size = 4096;
+    const size_t rx_buffer_size = 4096;
+    ESP_RETURN_ON_ERROR(uart_driver_install(CONFIG_EXAMPLE_UART_PORT_NUM, rx_buffer_size, tx_buffer_size, 0, NULL, ESP_INTR_FLAG_LOWMED), TAG, "uart_driver_install failed");
+
+    ESP_RETURN_ON_ERROR(uart_param_config(CONFIG_EXAMPLE_UART_PORT_NUM, &uart_config), TAG, "uart_param_config failed");
+
+    ESP_RETURN_ON_ERROR(uart_set_pin(CONFIG_EXAMPLE_UART_PORT_NUM, CONFIG_EXAMPLE_UART_TX_GPIO, CONFIG_EXAMPLE_UART_RX_GPIO, UART_PIN_NO_CHANGE, UART_PIN_NO_CHANGE), TAG, "uart_set_pin failed");
+
+    return ESP_OK;
+}
+
+static esp_err_t init_gpio(void)
+{
+    gpio_config_t io_conf = {
+        .pin_bit_mask = (1ULL << CONFIG_EXAMPLE_BOOT_GPIO) | (1ULL << CONFIG_EXAMPLE_EN_GPIO),
+        .mode = GPIO_MODE_OUTPUT,
+        .pull_up_en = GPIO_PULLUP_DISABLE,
+        .pull_down_en = GPIO_PULLDOWN_DISABLE,
+    };
+    ESP_RETURN_ON_ERROR(gpio_config(&io_conf), TAG, "gpio_config failed");
+    ESP_RETURN_ON_ERROR(gpio_set_level(CONFIG_EXAMPLE_BOOT_GPIO, 1), TAG, "gpio_set_level failed");
+    ESP_RETURN_ON_ERROR(gpio_set_level(CONFIG_EXAMPLE_EN_GPIO, 1), TAG, "gpio_set_level failed");
+    return ESP_OK;
+}
+
+static unsigned on_baudrate(void *ctx, unsigned baudrate)
+{
+    esp_err_t err = uart_set_baudrate(CONFIG_EXAMPLE_UART_PORT_NUM, baudrate);
+    if (err != ESP_OK) {
+        return 0;
+    }
+    return baudrate;
+}
+
+static rfc2217_control_t on_control(void *ctx, rfc2217_control_t requested_control)
+{
+    if (requested_control == RFC2217_CONTROL_SET_RTS) {
+        gpio_set_level(CONFIG_EXAMPLE_EN_GPIO, 0);
+    } else if (requested_control == RFC2217_CONTROL_CLEAR_RTS) {
+        gpio_set_level(CONFIG_EXAMPLE_EN_GPIO, 1);
+    } else if (requested_control == RFC2217_CONTROL_SET_DTR) {
+        gpio_set_level(CONFIG_EXAMPLE_BOOT_GPIO, 0);
+    } else if (requested_control == RFC2217_CONTROL_CLEAR_DTR) {
+        gpio_set_level(CONFIG_EXAMPLE_BOOT_GPIO, 1);
+    }
+    return requested_control;
+}

--- a/src/rfc2217_server.c
+++ b/src/rfc2217_server.c
@@ -128,7 +128,7 @@ static void on_client_ok(rfc2217_server_t server, bool ok);
 static void rfc2217_send_subnegotiation(rfc2217_server_t server, uint8_t command, const uint8_t *data, size_t size);
 static int telnet_options_init(rfc2217_server_t server);
 static void telnet_options_destroy(rfc2217_server_t server);
-
+static const uint8_t *find_iac_in_chunk(const uint8_t *data, size_t len);
 
 void telnet_option_process_incoming(telnet_option_t *option, uint8_t command)
 {
@@ -374,6 +374,11 @@ static void tcp_send(rfc2217_server_t server, const void *buf, size_t size)
     pthread_mutex_unlock(&server->tcp_send_mutex);
 }
 
+static const uint8_t *find_iac_in_chunk(const uint8_t *data, size_t len)
+{
+    return (const uint8_t *)memchr(data, T_IAC, len);
+}
+
 static void process_received_over_tcp(rfc2217_server_t server, const uint8_t *buf, size_t size)
 {
     // fast path: if we are not in telnet mode and there is no IAC, just pass the data on to the callback
@@ -461,7 +466,34 @@ int rfc2217_server_send_data(rfc2217_server_t server, const uint8_t *data, size_
         ESP_LOGE(TAG, "TCP receive thread is not running");
         return -1;
     }
-    tcp_send(server, data, len);
+
+    const uint8_t *iac_pos = find_iac_in_chunk(data, len);
+    if (iac_pos == NULL) {
+        tcp_send(server, data, len);
+    } else {
+        // Data contains IAC bytes - need to escape them
+        // Allocate buffer for worst case (all bytes are IAC = double size)
+        uint8_t *escaped_buffer = malloc(len * 2);
+        if (!escaped_buffer) {
+            ESP_LOGE(TAG, "Failed to allocate memory for IAC escaping");
+            return -1;
+        }
+
+        size_t escaped_len = 0;
+        for (size_t i = 0; i < len; i++) {
+            escaped_buffer[escaped_len++] = data[i];
+            if (data[i] == T_IAC) {
+                // Escape IAC by doubling it
+                escaped_buffer[escaped_len++] = T_IAC;
+            }
+        }
+
+        tcp_send(server, escaped_buffer, escaped_len);
+        free(escaped_buffer);
+
+        ESP_LOGD(TAG, "Sent %zu bytes with IAC escaping (original %zu bytes)", escaped_len, len);
+    }
+
     return 0;
 }
 

--- a/src/rfc2217_server.c
+++ b/src/rfc2217_server.c
@@ -527,7 +527,7 @@ static void process_subnegotiation(rfc2217_server_t server)
         if (server->config.on_baudrate) {
             new_baudrate = server->config.on_baudrate(server->config.ctx, baudrate);
         }
-        ESP_LOGD(TAG, "Set baudrate: requested %" PRIu32 ", accepted %" PRIu32, baudrate, baudrate);
+        ESP_LOGD(TAG, "Set baudrate: requested %" PRIu32 ", accepted %" PRIu32, baudrate, new_baudrate);
         uint8_t data[4] = {new_baudrate >> 24, new_baudrate >> 16, new_baudrate >> 8, new_baudrate};
         rfc2217_send_subnegotiation(server, T_SERVER_SET_BAUDRATE, data, 4);
     } else if (subnegotiation == T_SET_DATASIZE) {

--- a/src/rfc2217_server.c
+++ b/src/rfc2217_server.c
@@ -562,11 +562,10 @@ static void process_subnegotiation(rfc2217_server_t server)
         rfc2217_send_subnegotiation(server, T_SERVER_NOTIFY_MODEMSTATE, &server->suboption[2], 1);
     } else if (subnegotiation == T_PURGE_DATA) {
         uint8_t purge = server->suboption[2];
-        rfc2217_send_subnegotiation(server, T_SERVER_PURGE_DATA, &server->suboption[2], 1);
         rfc2217_purge_t purge_type = (rfc2217_purge_t)purge;
         rfc2217_purge_t purge_result = purge_type;
         if (server->config.on_purge) {
-            server->config.on_purge(server->config.ctx, purge_type);
+            purge_result = server->config.on_purge(server->config.ctx, purge_type);
         }
         ESP_LOGD(TAG, "Purge data: requested %d, accepted %d", purge_type, purge_result);
         uint8_t data[1] = {purge_result};


### PR DESCRIPTION
## Add esptool UART example with RFC2217 server

### Overview
This PR adds a new example that enables remote programming of ESP devices using esptool over the network via RFC2217 protocol. The solution is not ideal, but working. Flashing speed was around 65 kbit/s, which is quite good compared to normal flashing speed around 90 kbit/s (for UART). 

Main issue I have is really slow communication before flashing, `flash-id` command takes like 15 seconds. I did not investigate it, but would be nice if this can be improved, if you investigated it @igrr, please let me know if that can be improved, I might find some time to improve that (if not limited by the protocol).

### Main Feature
- **New esptool UART example** (`examples/uart_esptool/`): A complete RFC2217 server implementation that emulates a serial port for esptool communication
  - Supports DTR/RTS control signals (BOOT/EN GPIO) for putting target ESP devices into download mode
  - Enables remote programming over Wi-Fi/Ethernet using esptool with RFC2217 URLs
  - Includes comprehensive documentation and usage examples
  - Configurable UART pins and control signal GPIOs via menuconfig

### Bug Fixes Required for esptool Compatibility
During development and testing with esptool, several issues were discovered and fixed:

1. **IAC byte escaping** (`346f0d3`): Fixed handling of IAC (Interpret As Command) bytes in data streams to prevent protocol corruption
2. **Baudrate reporting** (`aec336a`): Corrected baudrate value in response messages when requested by clients
3. **Purge response** (`07e9637`): Fixed purge operation response format to match RFC2217 specification

### CI Updates
- **Pre-commit hooks update** (`16c510f`): Updated pre-commit configuration to ensure code quality standards

### Testing
- Tested with esptool for remote ESP32 programming

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds RFC2217-based esptool UART example and fixes protocol handling (IAC escaping, baudrate reporting, purge response) with minor CI/build updates.
> 
> - **Examples**:
>   - **New** `examples/uart_esptool/`: RFC2217 server for esptool (CMake, Kconfig, component deps, main implementation, README).
>   - Build rules: enable `examples/uart_esptool` for `IDF_TARGET == "esp32"` in `.build-test-rules.yml`.
> - **RFC2217 Core (`src/rfc2217_server.c`)**:
>   - Escape `IAC` bytes when sending data; add helper to detect `IAC`.
>   - Baudrate subnegotiation: respond with accepted `new_baudrate`.
>   - Purge subnegotiation: invoke callback and return accepted purge type.
> - **CI/Tooling**:
>   - Bump pre-commit hook versions (`astyle_py`, `pre-commit-hooks`, `doxybook`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 770f020c39dce5e3274967a0e761be3f432adc0e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->